### PR TITLE
Code Review: Make Zipped JSON our official File Format (#8880)

### DIFF
--- a/WebP.xcodeproj/project.pbxproj
+++ b/WebP.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		865C9AD01D79DFF400345AF9 /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = 865C9AB61D79DFF400345AF9 /* thread.h */; };
 		865C9AD11D79DFF400345AF9 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 865C9AB71D79DFF400345AF9 /* utils.c */; };
 		865C9AD21D79DFF400345AF9 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 865C9AB81D79DFF400345AF9 /* utils.h */; };
+		866BE8271DA2B7C5004BD6D8 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 866BE8261DA2B7C5004BD6D8 /* libz.tbd */; };
+		866BE8291DA2B7CC004BD6D8 /* libMinizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 866BE8281DA2B7CC004BD6D8 /* libMinizip.a */; };
 		86A35A091D79BE80002DCEC2 /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = 86A359F91D79BE80002DCEC2 /* alpha.c */; };
 		86A35A0A1D79BE80002DCEC2 /* alphai.h in Headers */ = {isa = PBXBuildFile; fileRef = 86A359FA1D79BE80002DCEC2 /* alphai.h */; };
 		86A35A0B1D79BE80002DCEC2 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 86A359FB1D79BE80002DCEC2 /* buffer.c */; };
@@ -264,6 +266,8 @@
 		865C9AB61D79DFF400345AF9 /* thread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = thread.h; path = src/utils/thread.h; sourceTree = SOURCE_ROOT; };
 		865C9AB71D79DFF400345AF9 /* utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = utils.c; path = src/utils/utils.c; sourceTree = SOURCE_ROOT; };
 		865C9AB81D79DFF400345AF9 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = utils.h; path = src/utils/utils.h; sourceTree = SOURCE_ROOT; };
+		866BE8261DA2B7C5004BD6D8 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		866BE8281DA2B7CC004BD6D8 /* libMinizip.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libMinizip.a; path = "../../../../../Library/Developer/Xcode/DerivedData/Sketch-fjbukfedngjgmzaszlpcioezcwks/Build/Products/Release/libMinizip.a"; sourceTree = "<group>"; };
 		86A359F91D79BE80002DCEC2 /* alpha.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = alpha.c; path = src/dec/alpha.c; sourceTree = SOURCE_ROOT; };
 		86A359FA1D79BE80002DCEC2 /* alphai.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = alphai.h; path = src/dec/alphai.h; sourceTree = SOURCE_ROOT; };
 		86A359FB1D79BE80002DCEC2 /* buffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = buffer.c; path = src/dec/buffer.c; sourceTree = SOURCE_ROOT; };
@@ -346,6 +350,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				866BE8291DA2B7CC004BD6D8 /* libMinizip.a in Frameworks */,
+				866BE8271DA2B7C5004BD6D8 /* libz.tbd in Frameworks */,
 				86DA98EA1D7DDE7F0063A34F /* libECLogging.a in Frameworks */,
 				86DA98E81D7DDE250063A34F /* libBCFoundation.a in Frameworks */,
 				86DA98E61D7DDE070063A34F /* libChocolat.a in Frameworks */,
@@ -430,6 +436,8 @@
 		5B42DEAF1A63E44F0025C1EA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				866BE8281DA2B7CC004BD6D8 /* libMinizip.a */,
+				866BE8261DA2B7C5004BD6D8 /* libz.tbd */,
 				86DA98E91D7DDE7F0063A34F /* libECLogging.a */,
 				86DA98E71D7DDE250063A34F /* libBCFoundation.a */,
 				86DA98E51D7DDE070063A34F /* libChocolat.a */,


### PR DESCRIPTION
Code review for Make Zipped JSON our official File Format (#8880):

> In #8756 we wrote a proof-of-concept to test the various approaches. Zipped JSON was surprisingly small compared to what we have now, and it didn't increase in size that much. The benefit of being able to do/allow server-side file parsing makes this the preferred option. Let's build it! :-D
> 
> This'll be for @opsGavin since he built the POC, but also pinging in @samdeane and @mikeabdullah since I know he shares a keen interest in all things zip.
> 
> For now I think it makes sense to only use the Intermediate Value Tree (#9190) for unarchiving since we win nothing by using it for archiving too. Yet we'll make a pluggable NSCoding-like class so we can easily do it later if needed
> ## 
> 
> Things to look out for:
> 1. We use `ZipKit` already so we should either use that or make sure we update existing code to deal with `minizip' (which the POC used). Either way, we should have 1 zip package
> 2. Make sure QuickLook keeps working with new and old files
> 3. Even though our file format might for the moment only be 1 json file, it's expected that we'll have other files in there at some point so if we start with a zipped directory from the start that might make sense
> ## 
> 
> Possible steps to take:
> - [x] Replace our MSArchiver with a custom serialiser class so we can plug in a JSON serialiser later #9365
> - [x] Replace our MSUnarchiver with a custom deserialiser so we can plug in a JSON deserialiser later #9402
> - [x] Write the above serialiser #9401
> - [x] Write a deserialiser than reads in a mutable value tree, can perform migrations on that and then pass that to the immutables in a custom MSUnarchiver-type subclass #9403
> - [x] Wrap the new JSON in a zipped folder with images and a `metadata.json` and make Sketch archive and unarchive that besides keeping support for unarchiving the old SQL format
> - [x] Adapt the QL plugin to check for this image and fall back to an SQL read for the old format
> - [ ] Make sure we can do migrations and detect documents that are too new like we can now
> - [ ] Make sure missing fonts etc are recognises like they used to be
> - [x] Embed a preview of the first page in the Zip for QL and other tools
> - [ ] Make sure old versions of Sketch don't crash but display some kind of sensible error with encountering the new file
> - [ ] Make sure we can do some test migrations easily


Connect to BohemianCoding/Sketch#8880.